### PR TITLE
fix(cosmos-sdk-proto): correct GenesisState type name in slashing module

### DIFF
--- a/cosmos-sdk-proto/src/type_names.rs
+++ b/cosmos-sdk-proto/src/type_names.rs
@@ -137,7 +137,7 @@ impl_name!(
 impl_name!(
     cosmos::slashing::v1beta1::GenesisState,
     "cosmos.slashing.v1beta1",
-    "MissedBlocks"
+    "GenesisState"
 );
 impl_name!(
     cosmos::slashing::v1beta1::MissedBlock,


### PR DESCRIPTION
## Summary
Fixed an incorrect type name mapping in `cosmos-sdk-proto/src/type_names.rs`.

## Problem
The `impl_name!` macro for `cosmos::slashing::v1beta1::GenesisState` was incorrectly using `"MissedBlocks"` as its type name instead of `"GenesisState"`.

This was a copy-paste error that would cause incorrect type URL generation for the slashing module's `GenesisState` type, potentially breaking serialization/deserialization when working with Cosmos SDK protobuf messages.

## Changes
```diff
impl_name!(
    cosmos::slashing::v1beta1::GenesisState,
    "cosmos.slashing.v1beta1",
-    "MissedBlocks"
+    "GenesisState"
);